### PR TITLE
changed Coronavirus to COVID-19

### DIFF
--- a/index.html
+++ b/index.html
@@ -329,7 +329,7 @@
             <span class="label">3%</span>
             <div class="dotted-line"></div>
             <div class="description">
-              <h2>Test Every American for Coronavirus</h2>
+              <h2>Test Every American for COVID-19</h2>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Just a simple specification from "Coronavirus" to "COVID-19" in one line about what we could (and should!) do with the money belonging to 3% of American's richest people. "Coronavirus" is a group of related RNA viruses which makes pinning down the cost of testing every American a little difficult, where I believe the intention was to talk about the cost of testing every American for COVID-19.

 Very cool app! Excellent, work MKorostoff!