### PR TITLE
Prevent horizontal scrollbars on people and babies

### DIFF
--- a/main.css
+++ b/main.css
@@ -489,7 +489,8 @@ h1 {
 .people-wrapper {
   width: 800px;
   height: 400px;
-  overflow: scroll;
+  overflow-y: auto;
+  overflow-x: hidden;
 }
 .four-hundred-people .people {
   width: 800px;
@@ -713,7 +714,8 @@ h1 {
   box-shadow: inset 0 0 10px #00000042;
   width: 800px;
   height: 320px;
-  overflow: scroll;
+  overflow-y: scroll;
+  overflow-x: hidden;
 }
 .baby-counter {
   top: 127px;


### PR DESCRIPTION
`overflow: scroll` seems to force scrollbars even when not necessary. This fixes that, however the vertical scrollbar overlaps the content a bit. Could be fixed by setting .people-wrapper width to 816, but then you get a gap on systems that don't draw scrollbars.