### PR TITLE
Fix size of the bottom 60% display

### DIFF
--- a/main.css
+++ b/main.css
@@ -497,7 +497,7 @@ h1 {
 }
 .sixty-percent-people .people {
   width: 800px;
-  height: 197400px;
+  height: 1974000px;
 }
 .sixty-percent-people .people-wrapper {
   box-shadow: inset 0 0 10px #000000;
@@ -557,7 +557,7 @@ h1 {
   }
   .sixty-percent-people .people {
     width: 200px;
-    height: 394800000px;
+    height: 1974000px;
   }
   .people-label {
     left: 35px;


### PR DESCRIPTION
Unless I'm mistaken the calculations should be: 

`197.4e6 * (20*40) / 800 / 100 = 1974000` for the desktop version and
`197.4e6 * (10*20) / 200 / 100 = 1974000` for the mobile version.

Note that the mobile version, despite the vastly reduced size, still makes my browser throw up and render people stacked on top of each other, but the previous version didn't render at all, so I count this as a win.