### PR TITLE
Fixed incorrect percent

### DIFF
--- a/index.html
+++ b/index.html
@@ -562,7 +562,7 @@
 
         <div class="infobox text-infobox infobox-close">
           <div class="title">
-            Paid maternity and paternity leave are estimated to cost around <a href="https://www.americanactionforum.org/insight/the-fiscal-cost-of-a-paid-parental-leave-program-by-state/" target="_blank">$12 billion</a> per year. This is 0.39% of the wealth controlled by 400 Americans. It is 5% of the wealth they accrued in 2020 alone.
+            Paid maternity and paternity leave are estimated to cost around <a href="https://www.americanactionforum.org/insight/the-fiscal-cost-of-a-paid-parental-leave-program-by-state/" target="_blank">$12 billion</a> per year. This is 39% of the wealth controlled by 400 Americans. It is 5% of the wealth they accrued in 2020 alone.
           </div>
         </div>
 


### PR DESCRIPTION
Cost of paid maternity and paternity leave was shown to be 39% of wealth, then said to be 0.39%.