### PR TITLE
Fix constant vertical scroll bar with certain custom fonts

### DIFF
--- a/main.css
+++ b/main.css
@@ -23,7 +23,7 @@ h1 {
   height: 165px;
   position: absolute;
   right: 0;
-  bottom: 0;
+  bottom: 40px;
   padding-top: 42px;
   padding-left: 48px;
 


### PR DESCRIPTION
With some custom browser fonts, the text in div.instructions wraps more lines than intended, causing the page to be slightly taller regardless of zoom level. By offsetting .scroll-this-way by 40px from the bottom (the same amount as the top margin of .instructions), we should be able to prevent this issue.